### PR TITLE
Register generated zip files with MkDocs

### DIFF
--- a/zip_folders/plugin.py
+++ b/zip_folders/plugin.py
@@ -17,12 +17,25 @@ from mkdocs.structure.files import File
 log: logging.Logger = logging.getLogger("mkdocs")
 
 
+class PlaceholderFile(File):
+    def copy_file(self, *args, **kwargs):
+        pass
+
+
 class ZipFoldersPlugin(BasePlugin):
     config_scheme = (
         ('folders', config_options.Type(list, default=[])),
         ('debug', config_options.Type(bool, default=False)),
         ('hash_extension', config_options.Type(str, default='.zip.hash')),
     )
+
+    def on_files(self, files, config):
+        folders = self.config['folders']
+
+        for folder in folders:
+            files.append(PlaceholderFile.generated(
+                config, f'{folder}.zip', abs_src_path=os.path.join(config['site_dir'], f'{folder}.zip')
+            ))
 
     def on_post_build(self, config):
         folders = self.config['folders']

--- a/zip_folders/plugin.py
+++ b/zip_folders/plugin.py
@@ -43,7 +43,7 @@ class ZipFoldersPlugin(BasePlugin):
         for folder in folders:
             path = os.path.join(config['site_dir'], folder)
             if not os.path.exists(path):
-                print(f"The folder {folder} does not exist.")
+                log.warning(f"The folder {folder} does not exist.")
                 continue
 
             zip_path = f'{path}.zip'


### PR DESCRIPTION
Fixes https://github.com/JakubAndrysek/mkdocs-zip-folders/issues/1.

The general idea is that for each zip archive I register a placeholder file in `on_files`. MkDocs tries to copy the registered files to site_dir during the build, so I had to override `copy_file` to prevent errors from trying to read files that don't exist yet.